### PR TITLE
Enable compilation on C++20

### DIFF
--- a/re-spirv.cpp
+++ b/re-spirv.cpp
@@ -2310,8 +2310,6 @@ namespace respv {
         std::vector<Resolution> &resolutions;
         std::vector<uint8_t> &optimizedData;
         Options options;
-
-        OptimizerContext() = delete;
     };
 
     static void optimizerEliminateInstruction(uint32_t pInstructionIndex, OptimizerContext &rContext) {


### PR DESCRIPTION
Starting with C++20, deleted constructors can no longer be bypassed with bracket initialization. This is only relevant for `OptimizerContext`, and is circumvented by ~~setting up an explicit constructor~~ removing the default deleted constructor.