### PR TITLE
Skip terminator optimization when pruned target is a loop back-edge

### DIFF
--- a/re-spirv.cpp
+++ b/re-spirv.cpp
@@ -2785,14 +2785,44 @@ namespace respv {
         
         if (opCode == SpvOpBranchConditional) {
             // Branch conditional only needs to choose either label depending on whether the result is true or false.
+            uint32_t prunedLabelId;
             if (operatorResolution.value.u32) {
                 defaultLabelId = optimizedWords[wordIndex + 2];
-                optimizerReduceLabelDegree(optimizedWords[wordIndex + 3], rContext);
+                prunedLabelId = optimizedWords[wordIndex + 3];
             }
             else {
                 defaultLabelId = optimizedWords[wordIndex + 3];
-                optimizerReduceLabelDegree(optimizedWords[wordIndex + 2], rContext);
+                prunedLabelId = optimizedWords[wordIndex + 2];
             }
+
+            // Detect whether the pruned edge is a loop back-edge (a branch from inside a loop
+            // back to the loop header). Back-edges are intentionally skipped when building the
+            // adjacency list (see Shader::process) to prevent infinite cycles during the
+            // topological sort, which means they don't contribute to the target's in-degree.
+            // Reducing the degree here would erroneously cascade-eliminate the loop header
+            // (and via OpLoopMerge, the merge block as well), corrupting the SPIR-V into an
+            // invalid form ("Branch must appear in a block"). Removing the back-edge would
+            // also break the structured loop, since OpLoopMerge requires the continue block
+            // to branch back to the header, so skip the optimization in this case.
+            bool isBackEdge = false;
+            const uint32_t branchBlockIndex = rContext.shader.instructions[pInstructionIndex].blockIndex;
+            const uint32_t prunedInstructionIndex = rContext.shader.results[prunedLabelId].instructionIndex;
+            if ((branchBlockIndex != UINT32_MAX) && (prunedInstructionIndex != UINT32_MAX)) {
+                const uint32_t prunedBlockIndex = rContext.shader.instructions[prunedInstructionIndex].blockIndex;
+                if (prunedBlockIndex != UINT32_MAX) {
+                    const uint32_t branchPreOrder = rContext.shader.blockPreOrderIndices[branchBlockIndex];
+                    const uint32_t prunedPreOrder = rContext.shader.blockPreOrderIndices[prunedBlockIndex];
+                    const uint32_t branchPostOrder = rContext.shader.blockPostOrderIndices[branchBlockIndex];
+                    const uint32_t prunedPostOrder = rContext.shader.blockPostOrderIndices[prunedBlockIndex];
+                    isBackEdge = (branchPreOrder > prunedPreOrder) && (branchPostOrder < prunedPostOrder);
+                }
+            }
+
+            if (isBackEdge) {
+                return;
+            }
+
+            optimizerReduceLabelDegree(prunedLabelId, rContext);
 
             // If there's a selection merge before this branch, we place the unconditional branch in its place.
             const uint32_t mergeWordCount = 3;


### PR DESCRIPTION
_Disclaimer: AI tooling was used heavily in the planning and execution of this change. Any code not physically typed out by myself has been carefully reviewed to the best of my ability._

---

Fixes #17.

When `optimizerEvaluateTerminator` evaluates an `OpBranchConditional` whose condition is a constant and one target is the loop header (a back-edge), the in-degree reduction cascades incorrectly and corrupts the SPIR-V into:

```
error: Branch must appear in a block
```

Root cause: back-edges are intentionally excluded from the adjacency list in `Shader::process` (so the topological sort terminates), which means they don't contribute to the target's recorded in-degree. Calling `optimizerReduceLabelDegree` on a back-edge target drops the in-degree to zero and cascade-eliminates the loop header. The patch to `OpBranch` happens *after* the reduction returns, so the still-original `OpBranchConditional` gets iterated during the cascade and pushes the merge block back onto the elimination stack — the merge block is deleted too, and the patched `OpBranch` ends up orphaned.

See #17 for the full trace, reproducer SPIR-V, and downstream context (godotengine/godot#118389 — `do { } while (false);` in a shader hangs `vkCreateGraphicsPipelines` on Intel/Iris).

## Fix

Detect back-edges using the existing pre/post-order block indices (an edge `u → v` is a back-edge to ancestor `v` iff `pre[u] > pre[v] && post[u] < post[v]`) and skip the terminator optimization when the pruned target is one. The structured loop must remain intact — `OpLoopMerge` requires the continue block to branch back to the header, and rewriting that goes beyond what `optimizerEvaluateTerminator` should do here. The downstream driver compiler still folds the constant condition at SPIR-V → GPU translation time, so no real optimization is lost.

`OpSwitch` is unaffected: structured SPIR-V switches cannot have back-edge labels.

## Verification

Reproducer shader:

```glsl
#version 450
layout(location = 0) out float outX;
void main() {
    do { } while (false);
    outX = 1.0;
}
```

- Before: `spirv-val` reports `Branch must appear in a block` on the optimizer output.
- After: `spirv-val` passes; the original loop SPIR-V is preserved.

Also confirmed the fix builds (CMake) and the existing `re-spirv-cli` still produces valid output on a few non-loop test shaders.