### PR TITLE
Fix wrong instruction being used to reduce labels when merge loop instructions are present.

### DIFF
--- a/re-spirv.cpp
+++ b/re-spirv.cpp
@@ -2822,13 +2822,13 @@ namespace respv {
 
             if (terminatorReduced) {
                 // If there's a selection merge before this branch, we place the unconditional branch in its place.
-                const uint32_t mergeWordCount = 3;
-                uint32_t mergeWordIndex = wordIndex - mergeWordCount;
+                uint32_t mergeInstructionIndex = pInstructionIndex - 1;
+                uint32_t mergeWordIndex = rContext.shader.instructions[mergeInstructionIndex].wordIndex;
                 SpvOp mergeOpCode = SpvOp(optimizedWords[mergeWordIndex] & 0xFFFFU);
 
                 uint32_t patchWordIndex;
                 if (mergeOpCode == SpvOpSelectionMerge) {
-                    optimizerReduceLabelDegree(pInstructionIndex, optimizedWords[mergeWordIndex + 1], rContext);
+                    optimizerReduceLabelDegree(mergeInstructionIndex, optimizedWords[mergeWordIndex + 1], rContext);
                     patchWordIndex = mergeWordIndex;
                 }
                 else {


### PR DESCRIPTION
#fixes #20

I think there is a one off error when deleting a branch on a spec constant, the code is looking at the wrong instruction - the branch instead of the merge (but I do understand this very little). This fixes it for me, but please triple check this.